### PR TITLE
[WIP] Harmonize with new version of econ-project-templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ them in reverse chronological order.
   remove unnecessary packaging stuff.
 
 
-1.0.0 - 2021-01-05
+1.0.0 - 2022-01-05
 ------------------
 
 - :gh:`1` creates first release of a minimal cookiecutter template for a pytask project.

--- a/README.rst
+++ b/README.rst
@@ -53,4 +53,7 @@ A: This is called the src layout and the advantages are discussed in this `artic
 Hynek Schlawack <https://hynek.me/articles/testing-packaging/>`_.
 
 Although the article discusses the src layout in terms of Python packages, it is also
-beneficial to structure a project the same way.
+beneficial to structure a project the same way. Next to the reasons discussed there,
+it is possible to use a single Python environment for multiple projects without messing
+with your PYTHONPATH (via `python setup.py ...` or `conda develop ...`) each time and
+still import modules.

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,20 +1,27 @@
 """This module contains hooks which are executed before the template is rendered."""
 import re
 
-MODULE_REGEX = r"^[-_a-zA-Z0-9]*$"
+MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]*$"
 ENVIRON_REGEX = r"^[-_a-zA-Z0-9]*$"
-PYTHONVERSION_REGEX = r"^(3)\.[6-9]$"
+PYTHONVERSION_REGEX = r"^(3)\.(8|9|10)"
+PYTHONVERSION_MIN = "3.8"
 
 EXCEPTION_MSG_MODULE_NAME = """
-ERROR: The project slug ({module_name}) is not a valid Python module name.
-Please do not use anything other than letters, numbers, underscores '_',
-and minus signs '-'.
+ERROR: The project slug ({module_name}) is not a valid name.
+
+Please do not use anything other than letters, numbers, and underscores '_'.
+The first character must not be a number.
 """
 
 EXCEPTION_MSG_ENVIRON_NAME = """
 ERROR: The project slug ({environment_name}) is not a valid conda environment name.
+
 Please do not use anything other than letters, numbers, underscores '_',
 and minus signs '-'.
+"""
+
+EXCEPTION_MSG_PYTHONVERSION = """
+ERROR: The python version must be >= {PYTHONVERSION_MIN}, got {pythonversion}.
 """
 
 
@@ -33,7 +40,9 @@ def main():
     python_version = "{{ cookiecutter.python_version }}"
 
     if not re.match(PYTHONVERSION_REGEX, python_version):
-        raise ValueError("ERROR: The python version must be >= 3.6")  # noqa: TC003
+        raise ValueError(
+            EXCEPTION_MSG_PYTHONVERSION.format(PYTHONVERSION_MIN, python_version)
+        )
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -5,8 +5,8 @@ from pathlib import Path
 try:
     from ._version import version as __version__
 except ImportError:
-    # broken installation, we don't even try unknown only works because we do poor mans
-    # version compare
+    # Broken installation, we don't even try.
+    # Only works because we do poor man's version compare
     __version__ = "unknown"
 
 


### PR DESCRIPTION
Sync with https://github.com/OpenSourceEconomics/econ-project-templates/pull/98

To do with relevance for cookiecutter-project-template

- [ ] description re version in {{cookiecutter.project_slug}}/config.py unclear
- [ ] pytask.ini vs. tox.ini (why both?)
- [ ] add setup.py ?
- [ ] add empty docs ? 
- [ ] Top-level README.rst `:target: https://pypi.org/project/pytask` correct?
- [ ] Why is `ISSUE_TEMPLATE` in capital letters and `pull_request_template.md` not? Github requirement? I almost missed the latter...
- [ ] Document PR in CHANGES.rst.
