### PR TITLE
Small fixes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,6 @@
   "add_github_actions": ["yes", "no"],
   "add_mypy": ["yes", "no"],
   "add_readthedocs": ["yes", "no"],
-  "add_codecov": ["yes", "no"],
   "open_source_license": [
     "MIT",
     "BSD",

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -6,7 +6,7 @@ Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 file except in compliance with the License. You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -8,8 +8,7 @@ cookiecutter.project_slug }}/actions?query=branch%3Amain) {% endif %} {% if
 cookiecutter.add_readthedocs == "yes" %}[![image](https://readthedocs.org/projects/{{
 cookiecutter.project_slug | replace("_", "-") }}/badge/?version=stable)](https://{{
 cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/stable/?badge=stable)
-{% endif %} {% if cookiecutter.add_codecov == "yes"
-%}[![image](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{
+[![image](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{
 cookiecutter.project_slug }}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{
 cookiecutter.github_username }}/{{ cookiecutter.project_slug }}) {% endif %}
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/{{


### PR DESCRIPTION
Noted a couple of things while working on https://github.com/OpenSourceEconomics/econ-project-templates/pull/131

- Unsafe link
- I believe that GHA=y and codecov=n would have led to error in GHA because the workflow file is copied without rendering. Just assume codecov to be Y unless GHA not desired, all other fixes do not seem worth the cost to me.